### PR TITLE
Use logging library for output

### DIFF
--- a/catalog.dylan
+++ b/catalog.dylan
@@ -142,16 +142,16 @@ define function load-local-catalog
                  direction: #"input" /*,  I thought this was supposed to work:
                  if-does-not-exist: #f */)
     let (cat, num-packages, num-releases) = read-json-catalog(stream);
-    verbose-message("Loaded %d package%s with %d release%s from %s.\n",
-                    num-packages, iff(num-packages == 1, "", "s"),
-                    num-releases, iff(num-releases == 1, "", "s"),
-                    path);
+    log-trace("Loaded %d package%s with %d release%s from %s.",
+              num-packages, iff(num-packages == 1, "", "s"),
+              num-releases, iff(num-releases == 1, "", "s"),
+              path);
     validate-catalog(cat);
     cat
   end
 /*
   | begin
-      message("WARNING: No package catalog found in %s. Using empty catalog.\n", path);
+      log-warning("No package catalog found in %s. Using empty catalog.", path);
       make(<catalog>)
     end
 */

--- a/install.dylan
+++ b/install.dylan
@@ -72,7 +72,7 @@ define method %download
   let (exit-code, signal-code /* , process, #rest streams */)
     = os/run(command, output: #"null", error: #"null");
   if (exit-code = 0)
-    message("Downloaded %s to %s\n", release, dest-dir);
+    log-info("Downloaded %s to %s", release, dest-dir);
   else
     package-error("git clone command failed with exit code %d. Command: %=",
                   exit-code, command);
@@ -99,11 +99,11 @@ define method install
     install-deps(release, force?: force?);
   end;
   if (force? & installed?(release))
-    verbose-message("Deleting package %s for forced install.\n", release);
+    log-trace("Deleting package %s for forced install.", release);
     delete-directory(release-directory(release), recursive?: #t);
   end;
   if (installed?(release))
-    verbose-message("Package %s is already installed.\n", release);
+    log-trace("Package %s is already installed.", release);
   else
     download(release, source-directory(release));
     #t

--- a/library.dylan
+++ b/library.dylan
@@ -7,13 +7,14 @@ Synopsis: Dylan package manager
 
 define library pacman
   use common-dylan;
-  use system,
-    import: { date, file-system, locators, operating-system };
   use io,
     import: { format, format-out, print, streams };
   use json;
+  use logging;
   use regular-expressions;
   use strings;
+  use system,
+    import: { date, file-system, locators, operating-system };
   use uncommon-dylan,
     import: { uncommon-dylan, uncommon-utils };
   export
@@ -23,7 +24,6 @@ end library pacman;
 
 define module pacman
   export
-    set-verbose,
     load-catalog,
     <catalog-error>,
 
@@ -97,6 +97,7 @@ define module %pacman
               locator-name,
               merge-locators,
               subdirectory-locator };
+  use logging;
   use operating-system,
     import: { environment-variable => os/getenv,
               run-application => os/run };

--- a/packages.dylan
+++ b/packages.dylan
@@ -284,7 +284,7 @@ end function;
 
 define function read-package-file
     (file :: <file-locator>) => (release :: false-or(<release>))
-  verbose-message("Reading package file %s\n", file);
+  log-trace("Reading package file %s", file);
   block ()
     with-open-file (stream = file)
       let json = json/parse(stream, table-class: <istring-table>, strict?: #f);

--- a/pkg.json
+++ b/pkg.json
@@ -2,6 +2,7 @@
     "name": "pacman",
     "deps": [
         "json head",
+        "logging head",
         "regular-expressions head",
         "testworks head",
         "uncommon-dylan head"

--- a/utils.dylan
+++ b/utils.dylan
@@ -14,27 +14,6 @@ define function package-manager-directory
   subdirectory-locator(dylan-directory(), $package-directory-name)
 end function;
 
-define variable *verbose-output?* = #f;
-
-define function set-verbose (verbose? :: <bool>)
-  *verbose-output?* := verbose?
-end;
-
-define function message
-    (pattern :: <string>, #rest args) => ()
-  apply(format-out, pattern, args);
-  force-out();
-end;
-
-define function verbose-message
-    (pattern :: <string>, #rest args) => ()
-  if (*verbose-output?*)
-    apply(message, pattern, args);
-  end;
-end;
-
-ignorable(message, verbose-message);
-
 // TODO: Windows
 define constant $default-dylan-directory = "/opt/dylan";
 define constant $dylan-dir-name = "dylan";


### PR DESCRIPTION
`dylan-tool` sets the log level to `trace` when the `--verbose` flag is used. The `dylan-tool`, `pacman`, and `workspaces` libraries use `log-trace` for verbose output.