### PR TITLE
Implement "minimal version selection" for dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
 # pacman
 
-A package manager for Dylan. (This is a library, not the name of an executable,
-so there is no conflict with the `pacman` package manager for Arch Linux.)
+A package manager for Dylan. (This is a library, not the name of an executable, so there
+is no conflict with the `pacman` package manager for Arch Linux.)
 
-Find, download, install, and uninstall any version of any Dylan package and its dependencies.
+Find, download, install, and uninstall any version of any Dylan package and its
+dependencies.
 
 It isn't normally necessary to use this library directly. See the
-[dylan-tool](https://github.com/cgay/dylan-tool) documentation instead.
+[dylan-tool](https://github.com/dylan-lang/dylan-tool) documentation instead.
 
 See [this document](https://docs.google.com/document/d/13G6I1P2v9sULeV38pjOy-5EGhJme7BDQ52jQ0gO1peM/edit?usp=sharing)
 for some design discussion.
 
-See also: the [pacman-catalog](http://github.com/cgay/pacman-catalog) repository
+See also: the [pacman-catalog](http://github.com/dylan-lang/pacman-catalog) repository

--- a/deps.dylan
+++ b/deps.dylan
@@ -1,0 +1,221 @@
+Module: %pacman
+Synopsis: Dependency specification and resolution
+
+
+define class <dep-error> (<package-error>) end;
+
+// TODO(cgay): all the errors explicitly convert there args to strings because, for
+// reasons I never fully understood, the error printing code doesn't call the
+// print-object methods to print the args.
+
+define function dep-error
+    (format-string, #rest args)
+  signal(if (instance?(format-string, <condition>))
+           format-string
+         else
+           make(<dep-error>,
+                format-string: format-string,
+                format-arguments: args)
+         end);
+end function;
+
+define class <dep-conflict> (<dep-error>) end;
+
+// A dependency on a specific version of a package.
+define class <dep> (<object>)
+  constant slot package-name :: <string>, required-init-keyword: package-name:;
+  constant slot dep-version :: <version>, required-init-keyword: version:;
+end class;
+
+define method initialize
+    (dep :: <dep>, #key) => ()
+  next-method();
+  validate-package-name(dep.package-name);
+end method;
+
+define method print-object
+    (dep :: <dep>, stream :: <stream>) => ()
+  if (*print-escape?*)
+    printing-object (dep, stream)
+      write(stream, dep-to-string(dep));
+    end;
+  else
+    write(stream, dep-to-string(dep))
+  end;
+end method;
+
+define function dep-to-string
+    (dep :: <dep>) => (_ :: <string>)
+  if (dep.dep-version = $latest)
+    dep.package-name
+  else
+    concat(dep.package-name, "@", version-to-string(dep.dep-version))
+  end
+end function;
+
+// We want to avoid checking a lot of duplicate dependencies and this enables
+// preventing those duplicates with add-new!(..., dep, test: \=)
+define method \=
+    (d1 :: <dep>, d2 :: <dep>) => (_ :: <bool>)
+  istring=(d1.package-name, d2.package-name) & d1.dep-version = d2.dep-version
+end method;
+
+// Parse a dependency spec. Examples:
+//   foo            -- same as "foo@latest", i.e., latest numbered release
+//   foo@1.0        -- same as "foo@1.0.0"
+//   foo@1.2.3
+//   foo@feature    -- HEAD of the 'feature' branch
+//
+// TODO(cgay): I don't think "foo" or "foo@latest" should be supported at this level.  It
+// should probably be handled at the dylan-tool or workspaces level, and be explicitly
+// resolved to the latest <semantic-version> immediately.
+define function string-to-dep
+    (input :: <string>) => (d :: <dep>)
+  let (name, version) = apply(values, map(strip, split(strip(input), "@", count: 2)));
+  make(<dep>,
+       package-name: name,
+       version: if (version) string-to-version(version) else $latest end)
+end function;
+
+// Resolve `release` to a set of releases it depends on, using `cat` as the world of
+// potential releases. `release` itself is not included in the result. `active` maps
+// package names to releases that are "active" in the current workspace and therefore
+// should be treated specially. If any package encountered during resolution has a
+// dependency on one of the active packages, that dependency is ignored since the active
+// package will be used during the build process anyway. The returned deps do not include
+// the active releases.
+//
+// Signal <dep-error> if dependencies can't be resolved due to circularities or
+// conflicting constraints.
+//
+// The algorithm used here is based on my understanding of
+// https://research.swtch.com/vgo-principles, which can be very roughly summarized as
+// "providing repeatable builds by preferring the lowest possible specified version of
+// any package".
+//
+// We are given a release that needs to be built. This is the root of a graph. Its deps
+// form the second layer of a graph. The releases that match those deps form the third
+// level of the graph, and the deps of those releases form the fourth, etc. So we have a
+// graph in which the layers alternate between potential releases and their deps. This
+// tree gets big fast. The result for any given release is memoized.
+//
+// Each dep specifies only its minimum required version, e.g., P 1.2.3.  These are
+// semantic versions so if two P dependencies specify different major versions it is an
+// error.
+//
+// Releases with no deps terminate the recursion and as results percolate up the stack
+// they are combined with other results to keep only the maximum minimum version for each
+// package.
+//
+// (Note: We could support per-library dependencies (i.e., build deps). Test dependencies
+// should not be included in the graph for the main library. For example, to build pacman
+// testworks should not be a dependency. It's also possible to want to require D 1.0 for
+// one library in a package and D 2.0 for a different library in the same package. I'm
+// ignoring these issues for now to avoid unnecessary complexity. For now deps only work
+// at the package level.)
+define function resolve-deps
+    (release :: <release>, cat :: <catalog>,
+     #key active :: false-or(<istring-table>), cache = make(<table>))
+ => (releases :: <seq>)
+  local
+    method trace (depth, return-value, fmt, #rest format-args)
+      let indent = make(<string>, size: depth * 2, fill: ' ');
+      apply(log-trace, concat(indent, fmt), format-args);
+      return-value
+    end,
+    // Resolve the deps for a single release into a set of specific releases
+    // required in order to build it. The recursion terminates when a release
+    // has no deps or if a cached result exists.
+    method resolve-release (rel, seen, depth) => (releases)
+      trace(depth, #f, "resolve-release(rel: %=, seen: %=)", rel, seen);
+      let memo = element(cache, rel, default: #f); // use memoized result
+      if (memo)
+        trace(depth, memo, "<= memoized result %s", memo)
+      else
+        let pname = rel.package-name;
+        if (member?(pname, seen, test: \=))
+          dep-error("circular dependencies: %=", pair(pname, seen))
+        end;
+        // TODO: shouldn't need as(<list>) here
+        let resolved = resolve-deps(as(<list>, rel.release-deps), pair(pname, seen), depth + 1);
+        cache[rel] := resolved;
+        trace(depth, resolved, "caching %s => %s", rel, resolved);
+      end
+    end method,
+    // Iterate over a single release's deps resolving them to lists of specific minimum
+    // releases, then combine those releases into one list by taking the maximum minimum
+    // release version needed for each package.  When looking up deps, always prefer the
+    // active packages, so that it isn't necessary for the package to exist in the
+    // catalog.
+    method resolve-deps (deps, seen, depth)
+      trace(depth, #f, "resolve-deps(deps: %s, seen: %=)", deps, seen);
+      let maxima = make(<istring-table>);
+      for (dep in deps)
+        let pname = dep.package-name;
+        let rel = (active & element(active, pname, default: #f))
+                  | begin
+                      let pkg = find-package(cat, pname)
+                        | dep-error("package not found for %=", dep-to-string(dep));
+                      find-release(pkg, dep.dep-version, exact?: #f)
+                        | dep-error("no release found matching dependency %=",
+                                    dep-to-string(dep))
+                    end;
+        for (release in pair(rel, resolve-release(rel, seen, depth + 1)))
+          let pkg-name = release.package-name;
+          if (~(active & element(active, pkg-name, default: #f)))
+            let current-max = element(maxima, pkg-name, default: #f);
+            maxima[pkg-name] := max-release(current-max, release);
+          end;
+        end;
+      end;
+      let deps = as(<list>, value-sequence(maxima));
+      trace(depth, deps, "<= %s", deps);
+    end method;
+  let deps = resolve-release(release, #(), 0);
+  trace(0, deps, "Resolved %= to %s", release, deps)
+end function;
+
+// Find the newest of two releases. They could have semantic versions or branch versions,
+// which aren't really comparable. We prefer the branch version arbitrarily. Differing
+// branch versions or differing major version number for semantic versions causes a
+// `<dep-conflict>` error.
+//
+// TODO(cgay): include the path to each release in the error.
+define function max-release (current, release) => (r :: <release>)
+  if (~current)
+    release
+  else
+    let relver = release.release-version;
+    let curver = current.release-version;
+    if (instance?(relver, <branch-version>))
+      if (instance?(curver, <branch-version>))
+        if (relver ~= curver)
+          dep-error(make(<dep-conflict>,
+                         format-string: "dependencies on two different branches of"
+                           " the same package: %= and %=",
+                         format-arguments: list(release-to-string(current),
+                                                release-to-string(release))));
+        end;
+        current
+      else
+        release                // prefer branch version
+      end
+    else
+      if (instance?(curver, <branch-version>))
+        current                 // prefer branch version
+      else
+        // Both releases are SemVer.
+        let release-major = release.release-version.version-major;
+        let current-major = current.release-version.version-major;
+        if (release-major ~= current-major)
+          dep-error(make(<dep-conflict>,
+                         format-string: "dependencies on conflicting major versions"
+                           " of the same package: %= and %=",
+                         format-arguments: list(release-to-string(current),
+                                                release-to-string(release))));
+        end;
+        max(current, release)
+      end
+    end
+  end
+end function;

--- a/pacman.lid
+++ b/pacman.lid
@@ -1,6 +1,8 @@
 library: pacman
-files: library
-       utils
-       packages
-       catalog
-       install
+files: library.dylan
+       utils.dylan
+       versions.dylan
+       packages.dylan
+       catalog.dylan
+       deps.dylan
+       install.dylan

--- a/pkg.json
+++ b/pkg.json
@@ -1,11 +1,11 @@
 {
     "name": "pacman",
     "deps": [
-        "json head",
-        "logging head",
-        "regular-expressions head",
-        "testworks head",
-        "uncommon-dylan head"
+        "json@1.0",
+        "logging@2.0",
+        "regular-expressions@1.0",
+        "testworks@2.0",
+        "uncommon-dylan@0.2"
     ],
-    "location": "https://github.com/cgay/pacman"
+    "location": "https://github.com/dylan-lang/pacman"
 }

--- a/tests/catalog-test.dylan
+++ b/tests/catalog-test.dylan
@@ -12,11 +12,11 @@ define constant $catalog-text =
       "keywords": [ "http" ],
       "releases": {
         "1.0.0": {
-          "deps": [ "uri 4.0.9", "opendylan 2014.2.2" ],
+          "deps": [ "uri@4.0.9", "opendylan@2014.2.2" ],
           "location": "https://github.com/dylan-lang/http"
         },
         "2.10.0": {
-          "deps": [ "strings 2.3.4", "uri 6.1.0", "opendylan 2018.0.2" ],
+          "deps": [ "strings@2.3.4", "uri@6.1.0", "opendylan@2018.0.2" ],
           "location": "https://github.com/dylan-lang/http"
         }
       }
@@ -30,11 +30,11 @@ define constant $catalog-text =
       "keywords": [ "parser", "config", "serialize" ],
       "releases": {
         "1.0.0": {
-          "deps": [ "opendylan 2014.1.0" ],
+          "deps": [ "opendylan@2014.1.0" ],
           "location": "https://github.com/dylan-lang/json"
         },
         "3.1234.100": {
-          "deps": [ "strings 3.4.5", "opendylan 2018.8.8" ],
+          "deps": [ "strings@3.4.5", "opendylan@2018.8.8" ],
           "location": "https://github.com/dylan-lang/json"
         }
       }
@@ -43,9 +43,9 @@ define constant $catalog-text =
 
 define function get-test-catalog () => (_ :: <catalog>)
   with-input-from-string (in = $catalog-text)
-    read-json-catalog(in /* table-class: <ordered-string-table> */)
+    read-json-catalog(in)
   end
-end;
+end function;
 
 define test test-read-json-catalog ()
   let cat = get-test-catalog();
@@ -65,7 +65,7 @@ end;
 
 define test test-validate-dependencies ()
   // needs more...
-  assert-signals(<catalog-error>, validate-catalog(get-test-catalog()));
+  assert-signals(<package-error>, validate-catalog(get-test-catalog()));
 end;
 
 define test test-load-catalog ()

--- a/tests/deps-test.dylan
+++ b/tests/deps-test.dylan
@@ -1,0 +1,167 @@
+Module: pacman-test
+
+// Verify that dep names follow the same rules as package names.
+define test test-dep-name-validation ()
+  let version = string-to-version("1.0.0");
+  for (name in #["", "-x", "0foo", "abc%"])
+    assert-signals(<package-error>,
+                   make(<dep>, package-name: name, version: version),
+                   name);
+  end;
+  for (name in #["x", "X", "x-y", "x---", "a123", "a.test"])
+    assert-no-errors(make(<dep>, package-name: name, version: version), name);
+  end;
+end test;
+
+define test test-string-to-dep-to-string ()
+  assert-equal("p@1.2.3", dep-to-string(string-to-dep("p@1.2.3")));
+  assert-equal("p@1.2.0", dep-to-string(string-to-dep("p@1.2")));
+  assert-equal("p@branch", dep-to-string(string-to-dep("p@branch")));
+  assert-equal("p", dep-to-string(string-to-dep("p")));
+  assert-signals(<package-error>, string-to-dep("p@"));
+end test;
+
+define test test-dep-= ()
+  let dep1 = string-to-dep("p@0.1.2");
+  let dep2 = string-to-dep("p@0.1.2");
+  let dep3 = string-to-dep("p@0.1.8");
+  let dep4 = string-to-dep("x@0.1.2");
+  let dep5 = string-to-dep("z@branch");
+  assert-true(dep1 = dep2);
+  assert-false(dep1 = dep3);
+  assert-false(dep1 = dep4);
+  assert-false(dep1 = dep5);
+end test;
+
+define test test-max-release ()
+  let p123 = make-test-release("p@1.2.3");
+  let p124 = make-test-release("p@1.2.4");
+  let p133 = make-test-release("p@1.3.3");
+  let p223 = make-test-release("p@2.2.3");
+  let bfoo = make-test-release("p@foo");
+  let bbar = make-test-release("p@bar");
+  assert-equal(p123, max-release(p123, p123));
+  assert-equal(p124, max-release(p123, p124)); // patch different
+  assert-equal(p133, max-release(p123, p133)); // minor different
+  assert-equal(bfoo, max-release(p123, bfoo)); // branch considered newer
+  assert-signals(<dep-conflict>, max-release(p123, p223)); // different major incompatible
+  assert-signals(<dep-conflict>, max-release(bfoo, bbar)); // 2 branches not comparable
+end test;
+
+define test test-circular-dependency ()
+  // The most direct cyclic relationship.
+  assert-signals(<dep-error>,
+                 make-test-catalog(#("A@1.0", "B@1.0"),
+                                   #("B@1.0", "A@1.0")));
+  // Something with a longer cyclic chain.
+  assert-signals(<dep-error>,
+                 make-test-catalog(#("A@1.0", "B@1.0"),
+                                   #("B@1.0", "C@1.0"),
+                                   #("C@1.0", "D@foo"),
+                                   #("D@foo", "E@2.2"),
+                                   #("E@2.2", "A@1.0")));
+  // Same as previous but cirularity based on different release of A.  (In other words,
+  // this tests that circularities are solely based on the package name, not the release
+  // version.)
+  assert-signals(<dep-error>,
+                 make-test-catalog(#("A@1.0", "B@1.0"),
+                                   #("A@2.0", "B@1.0"), // added
+                                   #("B@1.0", "C@1.0"),
+                                   #("C@1.0", "D@foo"),
+                                   #("D@foo", "E@2.2"),
+                                   #("E@2.2", "A@2.0"))); // changed
+end test;
+
+define test test-missing-dependency ()
+  // strings@1.0 is listed as a dependency but only 1.1 and 2.0 are listed in the
+  // catalog. Although we _could_ choose to use strings@1.1 for this dependency since
+  // it's compatible with strings@1.0, it's preferable to disallow dependencies that
+  // don't exist in the catalog.
+  assert-signals(<dep-error>,
+                 make-test-catalog(#("strings@1.1"),
+                                   #("strings@2.0"),
+                                   #("B@1.0", "strings@1.0"),
+                                   #("C@1.0", "strings@2.0"),
+                                   #("A@1.0", "B@1.0", "C@1.0")));
+
+  // In this case there's a dependency on package D, which doesn't exist at all.
+  assert-signals(<dep-error>,
+                 make-test-catalog(#("B@1.0", "D@1.0"),
+                                   #("C@1.0", "D@2.0"),
+                                   #("A@1.0", "B@1.0", "C@1.0")));
+end test;
+
+define test test-dependency-conflict ()
+  // A depends on B and C which want different major versions of "strings".
+  assert-signals(<dep-conflict>,
+                 make-test-catalog(#("strings@1.0"),
+                                   #("strings@2.0"),
+                                   #("B@1.0", "strings@1.0"),
+                                   #("C@1.0", "strings@2.0"),
+                                   #("A@1.0", "B@1.0", "C@1.0")));
+  // Same as above but it's the minor version that differs, so no conflict.
+  assert-no-errors(make-test-catalog(#("strings@1.1"),
+                                     #("strings@1.2"),
+                                     #("B@1.0", "strings@1.1"),
+                                     #("C@1.0", "strings@1.2"),
+                                     #("A@1.0", "B@1.0", "C@1.0")));
+  // A depends on B and C which want different branches of "strings".
+  assert-signals(<dep-conflict>,
+                 make-test-catalog(#("strings@foo"),
+                                   #("strings@bar"),
+                                   #("B@1.0", "strings@foo"),
+                                   #("C@1.0", "strings@bar"),
+                                   #("A@1.0", "B@1.0", "C@1.0")));
+end test;
+
+define test test-minimal-version-selection ()
+  local
+    method verify (cat, top, expected-deps)
+      let dep = string-to-dep(top);
+      let release = find-package-release(cat, dep.package-name, dep.dep-version);
+      let got-deps = resolve-deps(release, cat);
+      let want-deps = map(method (d)
+                            let dep = string-to-dep(d);
+                            find-package-release(cat, dep.package-name, dep.dep-version);
+                          end,
+                          expected-deps);
+      // Note that resolve-deps does not include the given release in the return value.
+      assert-equal(got-deps.size, want-deps.size);
+      assert-equal(got-deps.size, intersection(got-deps, want-deps).size);
+    end;
+
+  // Example from https://research.swtch.com/vgo-principles#repeatability
+  // Both D@1.3 and D@1.4 are depended on. D@1.4 is compatible with D@1.3
+  // so 1.4 can be used.
+  let cat = make-test-catalog(#("A@1.20", "B@1.3", "C@1.8"),
+                              #("B@1.3", "D@1.3"),
+                              #("C@1.8", "D@1.4"),
+                              #("D@1.3"),
+                              #("D@1.4"));
+  verify(cat, "A@1.20", #("B@1.3", "C@1.8", "D@1.4"));
+
+  // Example from https://research.swtch.com/vgo-principles#sat-example
+  // Same as previous example except we add D@1.5 and make sure that it is NOT chosen
+  // since it is no release's minimal dependency. D@1.4 should still be used.
+  let cat = make-test-catalog(#("A@1.20", "B@1.3", "C@1.8"),
+                              #("B@1.3", "D@1.3"),
+                              #("C@1.8", "D@1.4"),
+                              #("D@1.3"),
+                              #("D@1.4"),
+                              #("D@1.5"));
+  verify(cat, "A@1.20", #("B@1.3", "C@1.8", "D@1.4"));
+
+  // The "broken" Go example from the same URL as above. Let's make sure ours breaks too.
+  // We're not actually doing a build, which is what would break in the example, so we
+  // just make sure the deps generated in the example are what we get.
+  let cat = make-test-catalog(#("A@1.21", "B@1.4", "C@1.8"),
+                              #("B@1.3", "D@1.3"),
+                              #("B@1.4", "D@1.6"),
+                              #("C@1.8", "D@1.4"),
+                              #("C@1.9", "D@1.4"),
+                              #("D@1.3"),
+                              #("D@1.4"),
+                              #("D@1.5"), // Not really needed since Go ignores it.
+                              #("D@1.6"));
+  verify(cat, "A@1.21", #("B@1.4", "C@1.8", "D@1.6"));
+end test;

--- a/tests/install-test.dylan
+++ b/tests/install-test.dylan
@@ -1,21 +1,7 @@
 Module: pacman-test
 
-define test install-test ()
-  let package = make(<package>,
-                     name: "pacman", // must be something in the live catalog
-                     summary: "a summary",
-                     description: "a description",
-                     contact: "an@address",
-                     license-type: "MIT",
-                     category: "dance moves");
-  let release = make(<release>,
-                     package: package,
-                     version: string-to-version("0.0.2"),
-                     deps: make(<dep-vector>, size: 0),
-                     // Work around dylan-mode indentation bug...
-                     location: "https:/" "/github.com/cgay/pacman");
-  package.package-releases[release.release-version.version-to-string]
-    := release;
+define test test-install ()
+  let release = make-test-release("pacman@0.0.2"); // must be in catalog
   let test-dir = subdirectory-locator(test-temp-directory(), "install-test");
   let pkg-dir = subdirectory-locator(test-dir, "pkg");
   environment-variable("DYLAN") := as(<byte-string>, test-dir);

--- a/tests/library.dylan
+++ b/tests/library.dylan
@@ -11,7 +11,7 @@ define library pacman-test
   use testworks;
   use uncommon-dylan,
     import: { uncommon-dylan, uncommon-utils };
-end;
+end library;
 
 define module pacman-test
   use file-system,
@@ -34,4 +34,4 @@ define module pacman-test
   use testworks;
   use uncommon-dylan,
     exclude: { format-to-string };
-end;
+end module;

--- a/tests/pacman-test.lid
+++ b/tests/pacman-test.lid
@@ -1,6 +1,9 @@
 library: pacman-test
 files: library.dylan
+       test-utils.dylan
        catalog-test.dylan
+       versions-test.dylan
        install-test.dylan
        types-test.dylan
+       deps-test.dylan
        main.dylan

--- a/tests/test-utils.dylan
+++ b/tests/test-utils.dylan
@@ -1,0 +1,51 @@
+Module: pacman-test
+
+// Make a <release> from a dependency spec like "pkg@1.2.3". If a catalog is given then
+// the release is added to the package with the same name in the catalog, if
+// any. Otherwise a new package is created. `deps` is also a sequence of dep specs for
+// the release.
+define function make-test-release
+    (dep-spec :: <string>, #key catalog, deps = #[]) => (release :: <release>)
+  let dep = string-to-dep(dep-spec);
+  let name = dep.package-name;
+  let pkg = catalog & find-package(catalog, name);
+  let package = pkg | make(<package>,
+                           name: name,
+                           summary: "summary",
+                           description: "description",
+                           contact: "contact@contact",
+                           license-type: "license-type",
+                           category: "category",
+                           releases: make(<stretchy-vector>));
+  let rel = catalog & find-package-release(catalog, name, dep.dep-version);
+  let release
+    = rel | make(<release>,
+                 package: package,
+                 version: dep.dep-version,
+                 deps: map-as(<dep-vector>, string-to-dep, deps),
+                 // test-install depends on this being a real repo.
+                 location: format-to-string("https://github.com/cgay/%s", name));
+  add!(package.package-releases, release);
+  sort!(package.package-releases, test: \>);
+  if (catalog & ~pkg)
+    // This is a new package; add it to the catalog.
+    catalog.all-packages[name] := package;
+  end;
+  release
+end function;
+
+// Make a catalog from a list of package specs. Each "spec" is a list like
+// #("p@1.2.3", "d@1.2.3", ...) where the first element is a release to add
+// to the catalog and the remaining elements are dependencies for that release.
+//
+define function make-test-catalog
+    (#rest package-specs) => (c :: <catalog>)
+  let catalog = make(<catalog>,
+                     packages: make(<istring-table>));
+  for (package-spec in package-specs)
+    // Mutate catalog...
+    make-test-release(head(package-spec), catalog: catalog, deps: tail(package-spec));
+  end;
+  validate-catalog(catalog);
+  catalog
+end function;

--- a/tests/types-test.dylan
+++ b/tests/types-test.dylan
@@ -2,9 +2,6 @@ Module: pacman-test
 
 define test version-=-test ()
   for (item in #[#["latest", "latest", #t],
-                 #["head", "head", #t],
-                 #["latest", "head", #f],
-                 #["head", "0.0.1", #f],
                  #["1.0.0", "1.0.0", #t],
                  #["0.1.0", "0.2.0", #f]])
     let (s1, s2, want) = apply(values, item);
@@ -18,78 +15,23 @@ define test version-=-test ()
 end;
 
 define test version-<-test ()
-  for (item in #[#["latest", "latest", #f],
-                 #["latest", "head", #t],
-                 #["head", "latest", #f],
-                 #["head", "0.0.1", #f],
-                 #["1.0.0", "1.0.0", #f],
-                 #["0.1.0", "0.2.0", #t],
-                 #["1.2.1", "1.3.0", #t]])
+  for (item in #[#["1.0.0",  "2.0.0", #t],  // major
+                 #["1.0.0",  "1.0.0", #f],
+                 #["2.0.0",  "1.0.0", #f],
+
+                 #["0.1.0",  "0.2.0", #t],  // minor
+                 #["1.2.1",  "1.2.1", #f],
+                 #["1.2.1",  "1.3.0", #t],
+
+                 #["1.2.3",  "1.2.4", #t],  // patch
+                 #["1.2.3",  "1.2.3", #f],
+                 #["1.2.4",  "1.2.3", #f]])
     let (s1, s2, want) = apply(values, item);
     let v1 = string-to-version(s1);
     let v2 = string-to-version(s2);
     let got = v1 < v2;
-    assert-equal(got, want,
-                 format-to-string("got %=, want %= for 'version(%s) < version(%s)'",
-                                  got, want, s1, s2));
+    check-equal(format-to-string("got %=, want %= for 'version(%s) < version(%s)'",
+                                 got, want, s1, s2),
+                got, want);
   end;
 end;
-
-define test dep-name-test ()
-  for (name in #["", "-x", "x_"])
-    assert-signals(<package-error>, make(<dep>, package-name: name), name);
-  end;
-  for (name in #["x", "X", "x-y", "x---"])
-    assert-no-errors(make(<dep>, package-name: name));
-  end;
-end test;
-
-define test bad-dep-versions-test ()
-  // The -beta1 bit may be supported in the future, but not now.
-  for (vstring in #["a.b.c", "4.5.6-beta1", "2.-3.4",
-                    "2", "2.", "2.3", "2.3.", "2.3.4.5",
-                    "0.0.0"]) // head
-    assert-signals(<package-error>, string-to-version(vstring),
-                   concat("for vstring = ", vstring));
-  end;
-  for (vstring in #["0.3.4", "3.4.0", "2018.12.25"])
-    assert-no-errors(string-to-version(vstring),
-                     concat("for vstring = ", vstring));
-  end;
-end test;
-
-define test good-dep-versions-test ()
-  for (item in list(#("p head", #f, #f),
-                    #("p 9.8.7", "9.8.7", "9.8.7"),
-                    #("p =99.88.77", "99.88.77", "99.88.77"),
-                    #("p >5.6.7", "5.6.7", #f),
-                    #("p <10.0.2", #f, "10.0.2")))
-    let (dep-string, minv, maxv) = apply(values, item);
-    let got = string-to-dep(dep-string);
-    let want = make(<dep>,
-                    package-name: "p",
-                    min-version: minv & string-to-version(minv),
-                    max-version: maxv & string-to-version(maxv));
-    assert-equal(got, want,
-                 format-to-string("for %=, got %=, want %=",
-                                  dep-string, dep-to-string(got), dep-to-string(want)));
-  end;
-end test;
-
-define test satisfies?-test ()
-  for (item in #(#("p *", #("1.0.0", "0.0.1"), #t),
-                 #("p 1.2.3", #("1.2.3"), #t),
-                 #("p 1.2.3", #("1.2.4"), #f),
-                 #("p >5.6.7", #("5.6.7", "5.6.8", "5.7.0", "6.0.1"), #t),
-                 #("p >5.6.7", #("5.6.6", "5.5.8", "4.7.8"), #f)
-                 // TODO: more...
-                 ))
-    let (dstring, vstrings, want) = apply(values, item);
-    let dep = string-to-dep(dstring);
-    for (vstring in vstrings)
-      let version = string-to-version(vstring);
-      assert-equal(satisfies?(dep, version), want,
-                   format-to-string("for dep %s and version %s", dstring, vstring));
-    end;
-  end;
-end test;

--- a/tests/versions-test.dylan
+++ b/tests/versions-test.dylan
@@ -1,0 +1,24 @@
+Module: pacman-test
+
+define test test-string-to-version ()
+  for (vstring in #["4.5.6-beta1", // may be supported in future
+                    "2.-3.4",
+                    "2",           // need at least major.minor
+                    "2.", "2.3.", "2.3.4.5",
+                    "0.0.0"])      // must have a non-zero component
+    assert-signals(<package-error>, string-to-version(vstring),
+                   "for vstring = %=", vstring);
+  end;
+  for (item in list(list("0.0.1", <semantic-version>),
+                    list("3.4.0", <semantic-version>),
+                    list("2018.12.25", <semantic-version>),
+                    list("LAtest", <latest>),
+                    list("master", <branch-version>),
+                    list("a.b.c", <branch-version>)))
+    let (vstring, class) = apply(values, item);
+    assert-no-errors(string-to-version(vstring),
+                     "for vstring = %=", vstring);
+    assert-equal(class, object-class(string-to-version(vstring)),
+                 "for vstring = %=", vstring);
+  end;
+end test;

--- a/versions.dylan
+++ b/versions.dylan
@@ -1,0 +1,153 @@
+Module: %pacman
+Synopsis: Support for semantic versions and branch versions
+
+// A version is a specification that points to a specific version control commit so that
+// an exact version of code may be retrieved. It might be a tag, a branch, or even a
+// specific commit hash.
+define abstract class <version> (<object>)
+end;
+
+// version-branch returns the name of the branch to checkout. For example "master" for
+// branch versions or "v1.2.3" for semantic versions. For Git this can be thought of as
+// the value of the `git clone --branch` flag.
+define generic version-branch (v :: <version>) => (branch :: <string>);
+
+// version-to-string returns the string representation of the version. For semantic
+// versions this is the bare "1.2.3" the patch number is always included, even if zero.
+define generic version-to-string (v :: <version>) => (s :: <string>);
+
+define method print-object
+    (v :: <version>, stream :: <stream>) => ()
+  if (*print-escape?*)
+    printing-object (v, stream)
+      write(stream, version-to-string(v));
+    end;
+  else
+    write(stream, version-to-string(v));
+  end;
+end method;
+
+
+// A semantic version as per the http://semver.org 2.0 specification. Note that only
+// numbered versions (semantic versions) appear in the catalog, and they are ordered
+// most-recent-first in the catalog, so they need methods on < and =, while other
+// versions don't.
+//
+// TODO(cgay): support <pre-release> and <build> specifiers, per the spec.
+define class <semantic-version> (<version>)
+  constant slot version-major :: <int>, required-init-keyword: major:;
+  constant slot version-minor :: <int>, required-init-keyword: minor:;
+  constant slot version-patch :: <int>, required-init-keyword: patch:;
+end class;
+
+define method version-to-string
+    (v :: <semantic-version>) => (s :: <string>)
+  format-to-string("%d.%d.%d", v.version-major, v.version-minor, v.version-patch)
+end;
+
+// Releases must be tagged with the SemVer prefixed by "v".
+define method version-branch
+    (v :: <semantic-version>) => (branch :: <string>)
+  concat("v", v.version-to-string)
+end;
+
+// A branch version, such as "master" or "cdb4af3". (Not yet sure if I'll need a separate
+// class for <commit-version>. Let's pretend we don't.) Branch versions can't be
+// published in the catalog and are only intended to be used during development.
+define class <branch-version> (<version>)
+  constant slot version-branch :: <string>, required-init-keyword: branch:;
+end class;
+
+define method version-to-string
+    (v :: <branch-version>) => (s :: <string>)
+  v.version-branch
+end;
+
+define method \=
+    (v1 :: <semantic-version>, v2 :: <semantic-version>) => (_ :: <bool>)
+  v1.version-major == v2.version-major
+    & v1.version-minor == v2.version-minor
+    & v1.version-patch == v2.version-patch
+end method;
+
+define method \=
+    (v1 :: <branch-version>, v2 :: <branch-version>) => (_ :: <bool>)
+  v1.version-branch = v2.version-branch
+end method;
+
+define method \<
+    (v1 :: <semantic-version>, v2 :: <semantic-version>) => (_ :: <bool>)
+  v1.version-major < v2.version-major
+    | (v1.version-major == v2.version-major
+         & (v1.version-minor < v2.version-minor
+              | (v1.version-minor == v2.version-minor
+                   & v1.version-patch < v2.version-patch)))
+end method;
+
+// Branch versions are for active development (at least in my current conception of how
+// things should work; this may change) so they are always newer (i.e., \>) than semantic
+// versions.
+define method \<
+    (v1 :: <branch-version>, v2 :: <semantic-version>) => (_ :: <bool>)
+  #f
+end method;
+
+define method \<
+    (v1 :: <semantic-version>, v2 :: <branch-version>) => (_ :: <bool>)
+  #t
+end method;
+
+define method \<
+    (v1 :: <branch-version>, v2 :: <branch-version>) => (_ :: <bool>)
+  v1.version-branch < v2.version-branch // arbitrary tie-breaker
+end method;
+
+
+
+// <latest> is a special version representing whatever the latest <semantic-version> for
+// a package. There is no way to compare <latest> to <branch-version>, and there is no
+// need to compare it to <semantic-version> since semantic versions in the catalog are
+// always sorted newest to oldest. <latest> is only allowed as a dependency in pkg.json
+// files, not in the catalog.
+define class <latest> (<version>, <singleton-object>) end;
+
+define constant $latest :: <latest> = make(<latest>);
+
+define method version-to-string
+    (v :: <latest>) => (s :: <string>)
+  $latest-name
+end;
+
+
+define constant $semantic-version-regex
+  = #:regex:{^(\d+)\.(\d+)(?:\.(\d+))?(-[0-9A-Za-z.-]+)?$};
+
+// Parse a version from a string such as "1.0" or "1.0.2". Major and minor version are
+// required. If patch is omitted it defaults to 0. Branch versions such as "master" are
+// also allowed, and the special string "latest" refers to the latest numbered version.
+define function string-to-version
+    (original-input :: <string>) => (_ :: <version>)
+  let input = strip(original-input);
+  let (match?, maj, min, pat, pre-release)
+    = re/search-strings($semantic-version-regex, input);
+  if (match?)
+    if (pre-release)
+      package-error("pre-release version specs are not yet supported: %=",
+                    original-input);
+    end;
+    maj := string-to-integer(maj);
+    min := string-to-integer(min);
+    pat := if (pat) string-to-integer(pat) else 0 end;
+    if (maj < 0 | min < 0 | pat < 0 | (maj + min + pat = 0))
+      package-error("invalid version spec %=", original-input);
+    end;
+    make(<semantic-version>, major: maj, minor: min, patch: pat)
+  elseif (istring=(input, "latest"))
+    $latest
+  elseif (empty?(input) | decimal-digit?(input[0]))
+    package-error("invalid version string: %=", original-input);
+  else
+    // Should really do more sanity checking on the branch name...
+    make(<branch-version>, branch: input)
+  end
+end function;


### PR DESCRIPTION
The algorithm used here is based on my understanding of
https://research.swtch.com/vgo-principles, which can be very roughly
summarized as "providing repeatable builds by preferring the lowest
possible specified version of any package".

Complex dependency constraints are dropped completely. Each package
specifies only a minimum acceptable version. If multiple packages
depend on P then the maximum minimal version of P is used. If two
packages require different major versions of P, it is an error.

A set of "active" packages may be passed to resolve-deps. No version
of an active package is ever included in the result. The idea being
that the active packages are usually checked out on a branch in the
user's workspace.