### PR TITLE
Include package file name in json error messages

### DIFF
--- a/library.dylan
+++ b/library.dylan
@@ -24,7 +24,7 @@ end library pacman;
 
 define module pacman
   export
-    dylan-directory,
+    dylan-directory,            // $DYLAN or $HOME/dylan or /opt/dylan
     load-catalog,
     <catalog-error>,
 
@@ -97,7 +97,8 @@ define module %pacman
               force-out };
   use json,
     import: { parse-json => json/parse,
-              encode-json => json/encode };
+              encode-json => json/encode,
+              <json-error> => json/<error> };
   use locators,
     import: { <directory-locator>,
               <file-locator>,


### PR DESCRIPTION
Added file locator slot to `<package>` class so that it may be used in error
messages.